### PR TITLE
Update JsonPatch.php

### DIFF
--- a/src/JsonPatch.php
+++ b/src/JsonPatch.php
@@ -520,14 +520,14 @@ class JsonPatch
     }
 
     // at target
-    if (!is_array($doc))
+    if (!is_array($doc) && null !== $doc)
     {
       throw new JsonPatchException('Target must be array or associative array');
     }
 
     if (!self::is_associative($doc)) // N.B. returns false for empty arrays
     {
-      if (count($doc) && !self::is_index($part)
+      if (@count($doc) && !self::is_index($part)
           && !($part == '-' && ($op == 'add' || $op == 'append')))
       {
         throw new JsonPatchException("Non-array key '$part' used on array");


### PR DESCRIPTION
Fix exceptions:

```
JsonPatchException: Target must be array or associative array

/var/www/app/vendor/mikemccabe/json-patch-php/src/JsonPatch.php:525
/var/www/app/vendor/mikemccabe/json-patch-php/src/JsonPatch.php:517
/var/www/app/vendor/mikemccabe/json-patch-php/src/JsonPatch.php:135
```

```
ErrorException: count(): Parameter must be an array or an object that implements Countable

/var/www/app/vendor/sentry/sentry/src/ErrorHandler.php:361
/var/www/app/vendor/mikemccabe/json-patch-php/src/JsonPatch.php:530
/var/www/app/vendor/mikemccabe/json-patch-php/src/JsonPatch.php:517
/var/www/app/vendor/mikemccabe/json-patch-php/src/JsonPatch.php:135
```


Such a patch generated by your fork:

```json
[    {
        "op": "add",
        "path": "\/average_salary\/value",
        "value": "16,2"
    },
    {
        "op": "add",
        "path": "\/average_salary\/suffix",
        "value": "тыс."
    },
    {
        "op": "add",
        "path": "\/average_salary\/currency",
        "value": "₽"
    }]
```

But could not apply it because `/average_salary` is `null`.